### PR TITLE
Option to skip test counting output using env

### DIFF
--- a/lib/request_urls.js
+++ b/lib/request_urls.js
@@ -6,9 +6,11 @@ var ExponentialBackoff = require( '../lib/ExponentialBackoff');
 var retries = 0;
 
 function printProgress(done, total) {
-  process.stderr.write(
-    '\rTests completed: '+ done + '/' + total + ' (retries: ' + retries + ')'
-  );
+  if (!process.env.SILENT_TEST_LOG) {
+    process.stderr.write(
+      '\rTests completed: '+ done + '/' + total + ' (retries: ' + retries + ')'
+    );
+  }
   if (done === total) {
     console.log(); //print a newline
   }


### PR DESCRIPTION
Because it floods the databuild log with useless noise